### PR TITLE
Added error handling for callControl API (fixes crash on mute/unmute)

### DIFF
--- a/app/src/main/scala/chat/tox/antox/av/Call.scala
+++ b/app/src/main/scala/chat/tox/antox/av/Call.scala
@@ -282,19 +282,36 @@ final case class Call(callNumber: CallNumber, contactKey: ContactKey, incoming: 
   }
 
   def muteFriendAudio(): Unit = {
-    ToxSingleton.toxAv.callControl(callNumber, ToxavCallControl.MUTE_AUDIO)
+    try {
+      ToxSingleton.toxAv.callControl(callNumber, ToxavCallControl.MUTE_AUDIO)
+    } catch {
+      case ex:Exception => logCallEvent(ex.toString)
+    }
   }
 
   def unmuteFriendAudio(): Unit = {
-    ToxSingleton.toxAv.callControl(callNumber, ToxavCallControl.UNMUTE_AUDIO)
+    try {
+      ToxSingleton.toxAv.callControl(callNumber, ToxavCallControl.UNMUTE_AUDIO)
+    } catch {
+      case ex:Exception => logCallEvent(ex.toString)
+    }
   }
 
   def hideFriendVideo(): Unit = {
-    ToxSingleton.toxAv.callControl(callNumber, ToxavCallControl.HIDE_VIDEO)
+    try {
+      ToxSingleton.toxAv.callControl(callNumber, ToxavCallControl.HIDE_VIDEO)
+    } catch {
+      case ex:Exception => logCallEvent(ex.toString)
+    }
+
   }
 
   def showFriendVideo(): Unit = {
-    ToxSingleton.toxAv.callControl(callNumber, ToxavCallControl.SHOW_VIDEO)
+    try {
+      ToxSingleton.toxAv.callControl(callNumber, ToxavCallControl.SHOW_VIDEO)
+    } catch {
+      case ex:Exception => logCallEvent(ex.toString)
+    }
   }
 
   def rotateCamera(): Unit = cameraFacingSubject.onNext(CameraFacing.swap(cameraFacingSubject.getValue))


### PR DESCRIPTION
Making an audio call, then clicking the second button (mute/unmute friend audio) three times will cause a crash due to an invalid state transition.  All calls to underlying APIs which can raise an exception should be caught, and this does just that.  The return values should also be checked, however I was not sure how we want to handle failure, so I am just taking this one step at a time.