### PR TITLE
Fix for Issue #388 - allow letters in ToxID to be either upper or lowercase

### DIFF
--- a/app/src/main/scala/chat/tox/antox/wrapper/ToxAddress.scala
+++ b/app/src/main/scala/chat/tox/antox/wrapper/ToxAddress.scala
@@ -7,7 +7,7 @@ object ToxAddress {
   val MAX_ADDRESS_LENGTH = 76
 
   def isAddressValid(address: String): Boolean = {
-    if (address.length != MAX_ADDRESS_LENGTH || !address.matches("^[0-9A-Fa-f]+$")) {
+    if (address.length != MAX_ADDRESS_LENGTH || !address.matches("^[0-9A-F]+$")) {
       return false
     }
 
@@ -37,16 +37,17 @@ object ToxAddress {
 }
 
 case class ToxAddress(address: String) {
-  if (!ToxAddress.isAddressValid(address)) {
+  def fixedAddress : String = ToxAddress.removePrefix(address.toUpperCase())
+  if (!ToxAddress.isAddressValid(fixedAddress)) {
     throw new IllegalArgumentException(s"address must be $ToxAddress.MAX_ADDRESS_LENGTH hex chars long")
   }
 
   def this(bytes: Array[Byte]) =
     this(Hex.bytesToHexString(bytes))
 
-  def bytes: Array[Byte] = Hex.hexStringToBytes(address)
+  def bytes: Array[Byte] = Hex.hexStringToBytes(fixedAddress)
 
-  def key: FriendKey = new FriendKey(address.toUpperCase().substring(0, ToxKey.MAX_KEY_LENGTH))
+  def key: FriendKey = new FriendKey(fixedAddress.substring(0, ToxKey.MAX_KEY_LENGTH))
 
-  override def toString: String = address.toUpperCase()
+  override def toString: String = fixedAddress
 }

--- a/app/src/main/scala/chat/tox/antox/wrapper/ToxAddress.scala
+++ b/app/src/main/scala/chat/tox/antox/wrapper/ToxAddress.scala
@@ -7,7 +7,7 @@ object ToxAddress {
   val MAX_ADDRESS_LENGTH = 76
 
   def isAddressValid(address: String): Boolean = {
-    if (address.length != MAX_ADDRESS_LENGTH || !address.matches("^[0-9A-F]+$")) {
+    if (address.length != MAX_ADDRESS_LENGTH || !address.matches("^[0-9A-Fa-f]+$")) {
       return false
     }
 

--- a/app/src/main/scala/chat/tox/antox/wrapper/ToxAddress.scala
+++ b/app/src/main/scala/chat/tox/antox/wrapper/ToxAddress.scala
@@ -46,7 +46,7 @@ case class ToxAddress(address: String) {
 
   def bytes: Array[Byte] = Hex.hexStringToBytes(address)
 
-  def key: FriendKey = new FriendKey(address.substring(0, ToxKey.MAX_KEY_LENGTH))
+  def key: FriendKey = new FriendKey(address.toUpperCase().substring(0, ToxKey.MAX_KEY_LENGTH))
 
-  override def toString: String = address
+  override def toString: String = address.toUpperCase()
 }


### PR DESCRIPTION
This updates isAddressValid() to accept hexidecimal with either uppercase or lowercase letters (or both).  This will make the interface slightly more user friendly (though entering a Tox ID by hand is still not very pleasant).