### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 
 Antox is an Android 4+ client for Tox created by [Mark Winter](https://github.com/Astonex). It aims to bring the full multimedia support Tox offers to your device, although it's still currently in heavy development. Antox is currently available for alpha testing on Google Play and F-Droid.
 
-###Screenshots
+### Screenshots
 
 <img src="http://i.imgur.com/PvY7zCQ.jpg" width="230px" height="400px"/> <img src="http://i.imgur.com/Hmnjpv3.png" width="230px" height="400px"/> <img src="http://i.imgur.com/jApGiZQ.png" width="230px" height="400px"/>
 
-###Current development
+### Current development
 
 - Android 6 (Marshmallow) permission support
 - Bugfixing A/V
 
-###Getting Antox
+### Getting Antox
 
 Antox can be downloaded from [Google Play](https://play.google.com/store/apps/details?id=chat.tox.antox).
 
@@ -24,19 +24,19 @@ To install on F-Droid, add `https://pkg.tox.chat/fdroid/repo` and search for "An
 
 The APK can be downloaded [here](https://pkg.tox.chat/fdroid/repo/antox.apk)
 
-###What Is Currently Working
+### What Is Currently Working
 - One to one messaging
 - File transfers
 - Avatars
 - Partial A/V support
 
-###Known Issues
+### Known Issues
 - Currently crashing on x86_64 devices, due to the tox4j library not currently supporting this arch. To find out if your device is running x86_64 Android, look for your device on [GSMArena](http://www.gsmarena.com/) and check your device's chipset. The most common x86_64 Android chipset is the Intel Atom.
 
-###Translating Antox
+### Translating Antox
 - You can localize the application via pull request or using [Transifex](https://www.transifex.com/antox/antox/).
 
-###Compiling Antox From Source with Android Studio
+### Compiling Antox From Source with Android Studio
 - Download https://developer.android.com/sdk/installing/studio.html
 - In Android Studio, go to Help>Check For Updates. As of writing, the latest version of AS is 2.2.3
 - In Android Studio again, go to Tools>Android>SDK Manager. Make sure you're using the latest SDK tools and SDK Build tools.
@@ -58,7 +58,7 @@ Alternatively, you can ignore this exception and read other information from the
 Currently there is no fix for this, but there is a workaround by disabling instant run. This can be done by going to `File > Settings > Build, Execution, Deployment > Instant Run` and unchecking enable.
 
 
-###Compiling Antox From Source using Gradle
+### Compiling Antox From Source using Gradle
 - Download and install the SDK tools http://developer.android.com/sdk/index.html#Other
 - Run `./download-dependencies.sh` (`download-dependencies.bat` on Windows)
 - Run the gradle wrapper `./gradlew build -x lint --parallel` (`gradlew.bat build -x lint --parallel` on Windows). This will download gradle to your project files to ensure you have the correct version of gradle for building
@@ -66,7 +66,7 @@ Currently there is no fix for this, but there is a workaround by disabling insta
 - The apk will then be available in `app/build/outputs/apk/`
 - To install the app via ADB, run `adb install <apk file>` 
 
-###Remarks
+### Remarks
 
 *The Android robot is reproduced or modified from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.*
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
