### PR TITLE
AvatarView leads to friend's profile 

### DIFF
--- a/app/src/main/res/menu/chat_menu.xml
+++ b/app/src/main/res/menu/chat_menu.xml
@@ -10,9 +10,4 @@
         android:icon="@drawable/ic_action_video"
         android:title="@string/video_call_friend"
         antox:showAsAction="ifRoom" />
-    <item
-        android:id="@+id/user_info"
-        android:icon="@drawable/ic_info"
-        android:title="@string/info"
-        antox:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/scala/chat/tox/antox/activities/ChatActivity.scala
+++ b/app/src/main/scala/chat/tox/antox/activities/ChatActivity.scala
@@ -262,7 +262,7 @@ class ChatActivity extends GenericChatActivity[FriendKey] {
     startActivity(callActivity)
   }
 
-  override def onClickInfo(clickLocation: Location): Unit = {
+  override def onClickInfo(): Unit = {
     val intent = new Intent(this, classOf[FriendProfileActivity])
     val friendInfo = State.db.getFriendInfo(activeKey)
     intent.putExtra("key", activeKey.key)

--- a/app/src/main/scala/chat/tox/antox/activities/GenericChatActivity.scala
+++ b/app/src/main/scala/chat/tox/antox/activities/GenericChatActivity.scala
@@ -96,7 +96,7 @@ abstract class GenericChatActivity[KeyType <: ContactKey] extends AppCompatActiv
     avatarActionView = this.findViewById(R.id.avatarActionView)
     avatarActionView.setOnClickListener(new View.OnClickListener() {
       override def onClick(v: View) {
-        thisActivity.finish()
+        onClickInfo()
       }
     })
 
@@ -182,10 +182,6 @@ abstract class GenericChatActivity[KeyType <: ContactKey] extends AppCompatActiv
 
       case R.id.video_call_button =>
         onClickVideoCall(clickLocation)
-        true
-
-      case R.id.user_info =>
-        onClickInfo()
         true
 
       case _ =>

--- a/app/src/main/scala/chat/tox/antox/activities/GenericChatActivity.scala
+++ b/app/src/main/scala/chat/tox/antox/activities/GenericChatActivity.scala
@@ -185,7 +185,7 @@ abstract class GenericChatActivity[KeyType <: ContactKey] extends AppCompatActiv
         true
 
       case R.id.user_info =>
-        onClickInfo(clickLocation)
+        onClickInfo()
         true
 
       case _ =>
@@ -305,5 +305,5 @@ abstract class GenericChatActivity[KeyType <: ContactKey] extends AppCompatActiv
 
   def onClickVideoCall(clickLocation: Location): Unit
 
-  def onClickInfo(clickLocation: Location): Unit
+  def onClickInfo(): Unit
 }

--- a/app/src/main/scala/chat/tox/antox/activities/GroupChatActivity.scala
+++ b/app/src/main/scala/chat/tox/antox/activities/GroupChatActivity.scala
@@ -63,7 +63,7 @@ class GroupChatActivity extends GenericChatActivity[GroupKey] {
     // not yet implemented in toxcore
   }
 
-  override def onClickInfo(clickLocation: Location): Unit = {
+  override def onClickInfo(): Unit = {
     //TODO add a group profile activity
   }
 


### PR DESCRIPTION
I found a bit counterintuitive using the click on avatar as a way to go back and using a specific button for this purpose. AvatarView click listener's functionality has been replaced then by the user_info button functionality, wich also mades not necessary to keep the button inside the Chat UI.